### PR TITLE
Fix typo in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.6</version>
 				<configuration>
-					<finalName>labkit-snakemake-exmaple-${project.version}</finalName>
+					<finalName>labkit-snakemake-example-${project.version}</finalName>
 					<appendAssemblyId>false</appendAssemblyId>
 					<descriptors>
 						<descriptor>src/main/assembly/zip.xml</descriptor>


### PR DESCRIPTION
The snakemake example filename contained a typo.